### PR TITLE
Gunicorn threads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN apk add -qU --no-cache -t .devstuff gcc musl-dev git \
     &&  pipenv install \
     &&  apk del -q .devstuff
 EXPOSE 5000
-CMD pipenv run gunicorn -w $SEEDS_NUMBER -b 0.0.0.0:5000 main:app
+CMD pipenv run gunicorn --threads=$(expr $SEEDS_NUMBER \* 2) -b 0.0.0.0:5000 main:app

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,11 +2,11 @@ version: '3'
 
 services:
   faucet:
-    image: kinecosystem/stellar-faucet:0.6
+    image: kinecosystem/stellar-faucet:d4e6db
     ports:
       - 5000:5000/tcp
     environment:
-      SEEDS_NUMBER: 9
+      SEEDS_NUMBER: 4
       HORIZON_ENDPOINT: https://horizon-testnet.stellar.org/
       NETWORK_PASSPHRASE: Test SDF Network ; September 2015
       KIN_ISSUER: GCKG5WGBIJP74UDNRIRDFGENNIH5Y3KBI5IHREFAJKV4MQXLELT7EX6V

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   faucet:
     image: kinecosystem/stellar-faucet:d4e6db
     ports:
-      - 5000:5000/tcp
+      - 80:5000
     environment:
       SEEDS_NUMBER: 4
       HORIZON_ENDPOINT: https://horizon-testnet.stellar.org/


### PR DESCRIPTION
After talking with Doody, and looking at David's code for atn-xp, we noticed that using threads is the correct way to work with channels, and not gunicorn workers.

This PR 
1. Switches from gunicorn workers > threads
2. Changes the default compose port for easier use